### PR TITLE
updated sitemap generator to use canonical domain URL

### DIFF
--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -8,4 +8,4 @@ Disallow: /dashboard
 Disallow: /new-post
 Disallow: /edit-post/
 
-Sitemap: https://stacknova.ca/sitemap.xml
+Sitemap: https://api.stacknova.ca/sitemap.xml

--- a/server/utils/sitemapGenerator.js
+++ b/server/utils/sitemapGenerator.js
@@ -118,9 +118,9 @@ async function generateSitemap(req) {
     }
     
     // Build the base URL from the request
-    const protocol = req.protocol;
-    const host = req.get('host');
-    const baseUrl = `${protocol}://${host}`;
+    const baseUrl = process.env.NODE_ENV === 'production' 
+      ? 'https://stacknova.ca'  // Hardcoded frontend URL for production
+      : `${req.protocol}://${req.get('host')}`;
     
     // Create a sitemap stream
     const sitemapStream = new SitemapStream({ 


### PR DESCRIPTION
- Changed sitemap generator to use hardcoded stacknova.ca as the canonical domain
- Ensures all URLs in sitemap point to frontend rather than API domain
- Improves SEO by maintaining consistent domain references