### PR TITLE
implement SEO-friendly slug URLs for posts

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -19,7 +19,8 @@ const router = createBrowserRouter([
     errorElement: <NotFound />,
     children: [
       { index: true, element: <ErrorBoundary><Posts /></ErrorBoundary> },
-      { path: "post/:id", element: <ErrorBoundary><PostDetails /></ErrorBoundary> },
+      // { path: "post/:slug", element: <ErrorBoundary><PostDetails /></ErrorBoundary> },
+      { path: "post/:identifier", element: <ErrorBoundary><PostDetails /></ErrorBoundary> },
       {
         path: "user/:username",
         element: <UserProfileWrapper />
@@ -36,7 +37,7 @@ const router = createBrowserRouter([
             element: <DashboardWrapper />
           },
           { path: "new-post", element: <ErrorBoundary><NewPost /></ErrorBoundary> },
-          { path: "edit-post/:id", element: <ErrorBoundary><EditPost /></ErrorBoundary> },
+          { path: "edit-post/:slug", element: <ErrorBoundary><EditPost /></ErrorBoundary> },
         ],
       },
       { path: "*", element: <NotFound /> }

--- a/client/src/pages/Dashboard/components/PostItem.jsx
+++ b/client/src/pages/Dashboard/components/PostItem.jsx
@@ -8,15 +8,15 @@ export const PostItem = ({ post, onDeleteClick, prefetchPost }) => (
                dark:shadow-black/20 overflow-hidden 
                border border-gray-200 dark:border-gray-700
                hover:border-blue-500 dark:hover:border-blue-400"
-    aria-labelledby={`post-title-${post.id}`}
+    aria-labelledby={`post-title-${post.slug}`}
   >
     <div className="p-4">
-      <h3 id={`post-title-${post.id}`} className="mb-2">
+      <h3 id={`post-title-${post.slug}`} className="mb-2">
         <Link
-          to={`/post/${post.id}`}
+          to={`/post/${post.slug}`}
           className="text-xl font-semibold text-blue-600 dark:text-blue-400 
           hover:text-blue-700 dark:hover:text-blue-500"
-          onMouseEnter={() => prefetchPost(post.id)} // Prefetch on hover
+          onMouseEnter={() => prefetchPost(post.slug)}
         >
           {post.title}
         </Link>
@@ -33,10 +33,10 @@ export const PostItem = ({ post, onDeleteClick, prefetchPost }) => (
         </time>
         <div className="flex gap-2">
           <Link
-            to={`/edit-post/${post.id}`}
+            to={`/edit-post/${post.slug}`}
             className="text-gray-700 dark:text-gray-400 hover:text-blue-500 cursor-pointer"
             aria-label={`Edit post: ${post.title}`}
-            onMouseEnter={() => prefetchPost(post.id)} // Prefetch on hover
+            onMouseEnter={() => prefetchPost(post.slug)}
           >
             <Edit2 size={18} aria-hidden="true" />
           </Link>

--- a/client/src/pages/Dashboard/hooks/useDeletePost.js
+++ b/client/src/pages/Dashboard/hooks/useDeletePost.js
@@ -1,29 +1,76 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAuth } from '../../../context/AuthContext';
 
 export const useDeletePost = ({ userId, onSuccess }) => {
   const queryClient = useQueryClient();
+  const { user } = useAuth();
 
   const deletePostMutation = useMutation({
-    mutationFn: async (postId) => {
-      const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/posts/${postId}`, {
+    mutationFn: async (postSlugOrId) => {
+      // The backend controller handles both slug and ID
+      const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/posts/${postSlugOrId}`, {
         method: 'DELETE',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ userId }), // Send userId in the request body
-        credentials: 'include' // Include credentials for cross-domain sessions
+        credentials: 'include'
       });
       if (!response.ok) throw new Error('Failed to delete post');
     },
-    onSuccess: async () => {
-      // Invalidate and refetch
+    onSuccess: async (_, postSlugOrId) => {
+      // Remove individual post from cache
+      queryClient.removeQueries({
+        queryKey: ['post', postSlugOrId],
+        exact: true
+      });
+
+      // Optimistically update dashboard posts
+      const currentPosts = queryClient.getQueryData(['userPosts', userId]) || [];
+      if (Array.isArray(currentPosts)) {
+        const updatedPosts = currentPosts.filter(post =>
+          post.slug !== postSlugOrId && post.id !== postSlugOrId
+        );
+        queryClient.setQueryData(['userPosts', userId], updatedPosts);
+      }
+
+      // Optimistically update user profile cache if we have the username
+      if (user?.username) {
+        queryClient.setQueryData(['user', user.username], (oldData) => {
+          if (!oldData || !oldData.posts) return oldData;
+
+          return {
+            ...oldData,
+            posts: oldData.posts.filter(post =>
+              post.slug !== postSlugOrId && post.id !== postSlugOrId
+            )
+          };
+        });
+      }
+
+      // Optimistically update general posts list
+      const allPosts = queryClient.getQueryData(['posts']) || [];
+      if (Array.isArray(allPosts)) {
+        const updatedAllPosts = allPosts.filter(post =>
+          post.slug !== postSlugOrId && post.id !== postSlugOrId
+        );
+        queryClient.setQueryData(['posts'], updatedAllPosts);
+      }
+
+      // Invalidate relevant queries with proper patterns
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['userPosts', userId] }),
+        // Invalidate all user profile queries
+        queryClient.invalidateQueries({
+          queryKey: ['user'],
+          exact: false
+        }),
+        // Invalidate general posts list
         queryClient.invalidateQueries({ queryKey: ['posts'] }),
-        queryClient.invalidateQueries({ queryKey: ['user'] }),
+        // Specifically invalidate the current user's profile if we have the username
+        ...(user?.username ? [
+          queryClient.invalidateQueries({ queryKey: ['user', user.username] })
+        ] : [])
       ]);
-      
-      // Call the onSuccess callback
+
       if (onSuccess) {
         onSuccess();
       }
@@ -32,3 +79,117 @@ export const useDeletePost = ({ userId, onSuccess }) => {
 
   return { deletePostMutation };
 };
+
+// ----------------------------------------------------------------------------
+
+// import { useMutation, useQueryClient } from '@tanstack/react-query';
+// import { useAuth } from '../../../context/AuthContext';
+
+// export const useDeletePost = ({ userId, onSuccess }) => {
+//   const queryClient = useQueryClient();
+//   const { user } = useAuth();
+
+//   const deletePostMutation = useMutation({
+//     mutationFn: async (postSlugOrId) => {
+//       const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/posts/${postSlugOrId}`, {
+//         method: 'DELETE',
+//         headers: {
+//           'Content-Type': 'application/json',
+//         },
+//         credentials: 'include'
+//       });
+//       if (!response.ok) throw new Error('Failed to delete post');
+//     },
+//     onMutate: async (postSlugOrId) => {
+//       // Cancel any outgoing refetches
+//       await queryClient.cancelQueries({ queryKey: ['posts'] });
+//       await queryClient.cancelQueries({ queryKey: ['userPosts', userId] });
+//       if (user?.username) {
+//         await queryClient.cancelQueries({ queryKey: ['user', user.username] });
+//       }
+
+//       // Snapshot the previous values
+//       const previousPosts = queryClient.getQueryData(['posts']);
+//       const previousUserPosts = queryClient.getQueryData(['userPosts', userId]);
+//       const previousUserProfile = user?.username ? queryClient.getQueryData(['user', user.username]) : null;
+
+//       // Find the post being deleted to store it for potential rollback
+//       const deletedPost = Array.isArray(previousPosts)
+//         ? previousPosts.find(post => post.slug === postSlugOrId || post.id === postSlugOrId)
+//         : null;
+
+//       // Optimistically remove from posts list
+//       if (Array.isArray(previousPosts)) {
+//         const updatedPosts = previousPosts.filter(post =>
+//           post.slug !== postSlugOrId && post.id !== postSlugOrId
+//         );
+//         queryClient.setQueryData(['posts'], updatedPosts);
+//       }
+
+//       // Optimistically remove from user posts
+//       if (Array.isArray(previousUserPosts)) {
+//         const updatedUserPosts = previousUserPosts.filter(post =>
+//           post.slug !== postSlugOrId && post.id !== postSlugOrId
+//         );
+//         queryClient.setQueryData(['userPosts', userId], updatedUserPosts);
+//       }
+
+//       // Optimistically remove from user profile
+//       if (user?.username && previousUserProfile) {
+//         queryClient.setQueryData(['user', user.username], {
+//           ...previousUserProfile,
+//           posts: previousUserProfile.posts?.filter(post =>
+//             post.slug !== postSlugOrId && post.id !== postSlugOrId
+//           ) || []
+//         });
+//       }
+
+//       // Remove individual post from cache
+//       queryClient.removeQueries({
+//         queryKey: ['post', postSlugOrId],
+//         exact: true
+//       });
+
+//       return {
+//         previousPosts,
+//         previousUserPosts,
+//         previousUserProfile,
+//         deletedPost,
+//         postSlugOrId
+//       };
+//     },
+//     onError: (err, postSlugOrId, context) => {
+//       // Rollback on error
+//       if (context?.previousPosts) {
+//         queryClient.setQueryData(['posts'], context.previousPosts);
+//       }
+//       if (context?.previousUserPosts) {
+//         queryClient.setQueryData(['userPosts', userId], context.previousUserPosts);
+//       }
+//       if (context?.previousUserProfile && user?.username) {
+//         queryClient.setQueryData(['user', user.username], context.previousUserProfile);
+//       }
+
+//       // Restore the individual post cache if we have the deleted post data
+//       if (context?.deletedPost && context?.postSlugOrId) {
+//         queryClient.setQueryData(['post', context.postSlugOrId], context.deletedPost);
+//       }
+//     },
+//     onSuccess: async (_, postSlugOrId) => {
+//       // The optimistic update already happened, just call the success callback
+//       if (onSuccess) {
+//         onSuccess();
+//       }
+//     },
+//     onSettled: () => {
+//       // Refetch to ensure consistency
+//       queryClient.invalidateQueries({ queryKey: ['posts'] });
+//       queryClient.invalidateQueries({ queryKey: ['userPosts', userId] });
+//       if (user?.username) {
+//         queryClient.invalidateQueries({ queryKey: ['user', user.username] });
+//       }
+//     }
+//   });
+
+//   return { deletePostMutation };
+// };

--- a/client/src/pages/Dashboard/index.jsx
+++ b/client/src/pages/Dashboard/index.jsx
@@ -11,52 +11,44 @@ import { Pagination } from '../Posts/components/Pagination';
 import { SEO } from '../../components/SEO';
 import { useQueryClient } from '@tanstack/react-query';
 
-const ITEMS_PER_PAGE = 10; // Set the number of items per page
+const ITEMS_PER_PAGE = 10;
 
 const Dashboard = () => {
   const { user } = useAuth();
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [postToDelete, setPostToDelete] = useState(null);
-  const [currentPage, setCurrentPage] = useState(1); // Add state for current page
+  const [currentPage, setCurrentPage] = useState(1);
   const prefetchPost = usePrefetchPost();
   const queryClient = useQueryClient();
-  
-  // Check for prefetched data
+
   const prefetchedData = queryClient.getQueryData(['userPosts', user?.id]);
-  
-  // Fetch user's posts using custom hook with suspense if no prefetched data
+
   const { data: posts, error, refetch } = useDashboardPosts(user?.id, {
     suspense: !prefetchedData
   });
-  
-  // Delete post mutation using custom hook
+
   const { deletePostMutation } = useDeletePost({
     userId: user?.id,
     onSuccess: () => {
-      // Calculate the new total number of pages after deletion
       const newTotalItems = posts.length - 1;
       const newTotalPages = Math.ceil(newTotalItems / ITEMS_PER_PAGE);
-      
-      // If current page is now invalid, adjust it
+
       if (currentPage > newTotalPages && newTotalPages > 0) {
         setCurrentPage(newTotalPages);
       } else if (newTotalPages === 0) {
-        // If there are no posts left
         setCurrentPage(1);
       }
-      
+
       refetch();
       setDeleteModalOpen(false);
       setPostToDelete(null);
     }
   });
 
-  // Reset to first page when posts change significantly
   useEffect(() => {
     setCurrentPage(1);
   }, [user?.id]);
 
-  // Effect to handle body scroll lock when modal is open
   useEffect(() => {
     if (deleteModalOpen) {
       const scrollY = window.scrollY;
@@ -79,11 +71,10 @@ const Dashboard = () => {
 
   const handleConfirmDelete = () => {
     if (postToDelete) {
-      deletePostMutation.mutate(postToDelete.id);
+      deletePostMutation.mutate(postToDelete.slug || postToDelete.id);
     }
   };
 
-  // Calculate pagination
   const totalPages = posts ? Math.ceil(posts.length / ITEMS_PER_PAGE) : 0;
   const paginatedPosts = posts ? posts.slice(
     (currentPage - 1) * ITEMS_PER_PAGE,
@@ -100,11 +91,10 @@ const Dashboard = () => {
         title="Dashboard"
         description="Manage your posts and activity on StackNova."
         canonicalPath="/dashboard"
-        noIndex={true} // Set noIndex to true based on robots.txt
+        noIndex={true}
       />
-      
+
       <div className="max-w-4xl mx-auto pb-8" id="dashboard-content">
-        {/* Delete Confirmation Modal */}
         <DeleteModal
           isOpen={deleteModalOpen}
           onClose={() => setDeleteModalOpen(false)}
@@ -114,17 +104,14 @@ const Dashboard = () => {
           itemType="Post"
         />
 
-        {/* Header Section */}
         <Header username={user?.username} />
 
-        {/* Posts Section */}
-        <PostsList 
+        <PostsList
           posts={paginatedPosts}
           onDeleteClick={handleDeleteClick}
           prefetchPost={prefetchPost}
         />
 
-        {/* Pagination Section */}
         {posts && posts.length > ITEMS_PER_PAGE && (
           <nav aria-label="Pagination" className="mt-8">
             <Pagination

--- a/client/src/pages/EditPost/components/EditPostForm.jsx
+++ b/client/src/pages/EditPost/components/EditPostForm.jsx
@@ -55,17 +55,17 @@ export const EditPostForm = ({ post, onSubmit, isSubmitting, error }) => {
           >
             Content
           </label>
-          <a 
-            href="https://stacknova.ca/post/e8adb6bf-6d5e-4bb2-95cd-a74449e5041b" 
-            target="_blank" 
+          <a
+            href="/post/formatting-guide"
+            target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-500 flex items-center gap-1 group"
           >
             Need help with formatting? View our guide
-            <ExternalLink 
-              size={16} 
-              className="inline-block transform transition-transform duration-200 group-hover:translate-x-0.5" 
-              aria-hidden="true" 
+            <ExternalLink
+              size={16}
+              className="inline-block transform transition-transform duration-200 group-hover:translate-x-0.5"
+              aria-hidden="true"
             />
           </a>
         </div>

--- a/client/src/pages/EditPost/hooks/usePostData.js
+++ b/client/src/pages/EditPost/hooks/usePostData.js
@@ -3,17 +3,22 @@ import { useNavigate } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { useAuth } from '../../../context/AuthContext';
 
-export const usePostData = (postId) => {
+export const usePostData = (postSlug) => {
   const navigate = useNavigate();
   const { user } = useAuth();
   const [error, setError] = useState('');
 
   // Fetch existing post
   const { data: post, isLoading } = useQuery({
-    queryKey: ['post', postId],
+    queryKey: ['post', postSlug],
     queryFn: async () => {
-      const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/posts/${postId}`);
-      if (!response.ok) throw new Error('Failed to fetch post');
+      const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/posts/${postSlug}`);
+      if (!response.ok) {
+        if (response.status === 404) {
+          throw new Error('Post not found');
+        }
+        throw new Error('Failed to fetch post');
+      }
       return response.json();
     },
     onError: (error) => {

--- a/client/src/pages/EditPost/hooks/useUpdatePost.js
+++ b/client/src/pages/EditPost/hooks/useUpdatePost.js
@@ -1,76 +1,195 @@
 import { useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../../context/AuthContext';
 import { POST_LIMITS } from '../../NewPost/constants';
 import { validateCodeBlocks } from '../../NewPost/utils';
 
-export const useUpdatePost = (postId) => {
+export const useUpdatePost = (postSlug) => {
   const [error, setError] = useState('');
   const navigate = useNavigate();
   const queryClient = useQueryClient();
+  const { user } = useAuth();
 
   const updatePostMutation = useMutation({
     mutationFn: async (updatedPost) => {
-      const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/posts/${postId}`, {
+      const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/posts/${postSlug}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(updatedPost),
-        credentials: 'include' // Include credentials for cross-domain sessions
+        credentials: 'include'
       });
-      
+
       const responseData = await response.json();
-      
+
       if (!response.ok) {
-        // If the server returned validation errors, format them nicely
         if (responseData.errors && Array.isArray(responseData.errors)) {
           const errorMessages = responseData.errors.map(err => err.msg).join('. ');
           throw new Error(errorMessages || 'Failed to update post');
         }
         throw new Error(responseData.message || 'Failed to update post');
       }
-      
+
       return responseData;
     },
-    onSuccess: () => {
-      // Invalidate relevant queries
-      queryClient.invalidateQueries({ queryKey: ['post', postId] });
-      queryClient.invalidateQueries({ queryKey: ['userPosts'] });
-      queryClient.invalidateQueries({ queryKey: ['posts'] });
-      queryClient.invalidateQueries({ queryKey: ['user'] });
-      // Navigate back to dashboard
-      navigate('/dashboard');
+    onMutate: async (updatedPostData) => {
+      // Cancel any outgoing refetches
+      await queryClient.cancelQueries({ queryKey: ['post', postSlug] });
+      await queryClient.cancelQueries({ queryKey: ['posts'] });
+      await queryClient.cancelQueries({ queryKey: ['userPosts', user?.id] });
+      if (user?.username) {
+        await queryClient.cancelQueries({ queryKey: ['user', user.username] });
+      }
+
+      // Snapshot the previous values
+      const previousPost = queryClient.getQueryData(['post', postSlug]);
+      const previousPosts = queryClient.getQueryData(['posts']);
+      const previousUserPosts = queryClient.getQueryData(['userPosts', user?.id]);
+      const previousUserProfile = user?.username ? queryClient.getQueryData(['user', user.username]) : null;
+
+      // Create optimistic updated post
+      const optimisticPost = {
+        ...previousPost,
+        title: updatedPostData.title,
+        content: updatedPostData.content,
+        excerpt: updatedPostData.content.substring(0, 150) + '...',
+        updatedAt: new Date().toISOString(),
+        // Note: slug might change on server, but we'll use the old one optimistically
+      };
+
+      // Optimistically update individual post cache
+      queryClient.setQueryData(['post', postSlug], optimisticPost);
+
+      // Optimistically update posts list
+      if (Array.isArray(previousPosts)) {
+        const updatedPosts = previousPosts.map(post =>
+          (post.slug === postSlug || post.id === previousPost?.id) ? optimisticPost : post
+        );
+        queryClient.setQueryData(['posts'], updatedPosts);
+      }
+
+      // Optimistically update user posts
+      if (Array.isArray(previousUserPosts)) {
+        const updatedUserPosts = previousUserPosts.map(post =>
+          (post.slug === postSlug || post.id === previousPost?.id) ? optimisticPost : post
+        );
+        queryClient.setQueryData(['userPosts', user?.id], updatedUserPosts);
+      }
+
+      // Optimistically update user profile
+      if (user?.username && previousUserProfile) {
+        queryClient.setQueryData(['user', user.username], {
+          ...previousUserProfile,
+          posts: previousUserProfile.posts?.map(post =>
+            (post.slug === postSlug || post.id === previousPost?.id) ? optimisticPost : post
+          ) || []
+        });
+      }
+
+      return {
+        previousPost,
+        previousPosts,
+        previousUserPosts,
+        previousUserProfile,
+        optimisticPost
+      };
     },
-    onError: (error) => {
-      setError(error.message);
+    onError: (err, updatedPostData, context) => {
+      // Rollback on error
+      if (context?.previousPost) {
+        queryClient.setQueryData(['post', postSlug], context.previousPost);
+      }
+      if (context?.previousPosts) {
+        queryClient.setQueryData(['posts'], context.previousPosts);
+      }
+      if (context?.previousUserPosts) {
+        queryClient.setQueryData(['userPosts', user?.id], context.previousUserPosts);
+      }
+      if (context?.previousUserProfile && user?.username) {
+        queryClient.setQueryData(['user', user.username], context.previousUserProfile);
+      }
+
+      setError(err.message);
+    },
+    onSuccess: async (data, variables, context) => {
+      const newSlug = data.post?.slug || postSlug;
+      const realPost = data.post;
+
+      // Update with real data from server
+      queryClient.setQueryData(['post', newSlug], realPost);
+
+      // If slug changed, remove old cache entry and navigate to new URL
+      if (newSlug !== postSlug) {
+        queryClient.removeQueries({ queryKey: ['post', postSlug] });
+      }
+
+      // Update posts list with real data
+      queryClient.setQueryData(['posts'], (oldPosts) => {
+        if (!Array.isArray(oldPosts)) return oldPosts;
+        return oldPosts.map(post =>
+          (post.slug === postSlug || post.id === realPost?.id) ? realPost : post
+        );
+      });
+
+      // Update user posts with real data
+      queryClient.setQueryData(['userPosts', user?.id], (oldPosts) => {
+        if (!Array.isArray(oldPosts)) return oldPosts;
+        return oldPosts.map(post =>
+          (post.slug === postSlug || post.id === realPost?.id) ? realPost : post
+        );
+      });
+
+      // Update user profile with real data
+      if (user?.username) {
+        queryClient.setQueryData(['user', user.username], (oldData) => {
+          if (!oldData) return oldData;
+          return {
+            ...oldData,
+            posts: oldData.posts?.map(post =>
+              (post.slug === postSlug || post.id === realPost?.id) ? realPost : post
+            ) || []
+          };
+        });
+      }
+
+      navigate(`/post/${newSlug}`, { replace: true });
+    },
+    onSettled: () => {
+      // Refetch to ensure consistency
+      queryClient.invalidateQueries({ queryKey: ['posts'] });
+      queryClient.invalidateQueries({ queryKey: ['userPosts', user?.id] });
+      if (user?.username) {
+        queryClient.invalidateQueries({ queryKey: ['user', user.username] });
+      }
     },
   });
 
   const handleUpdatePost = (postData) => {
     setError('');
 
-    // Client-side validation with specific error messages
+    // Client-side validation
     if (!postData.title.trim()) {
       setError('Title is required');
       return;
     }
-    
+
     if (postData.title.trim().length > POST_LIMITS.TITLE_MAX) {
       setError(`Title must be less than ${POST_LIMITS.TITLE_MAX} characters`);
       return;
     }
-    
+
     if (!postData.content.trim()) {
       setError('Content is required');
       return;
     }
-    
+
     if (postData.content.trim().length < POST_LIMITS.CONTENT_MIN) {
       setError(`Content must be at least ${POST_LIMITS.CONTENT_MIN} characters`);
       return;
     }
-    
+
     if (postData.content.trim().length > POST_LIMITS.CONTENT_MAX) {
       setError(`Content must be less than ${POST_LIMITS.CONTENT_MAX} characters`);
       return;

--- a/client/src/pages/EditPost/index.jsx
+++ b/client/src/pages/EditPost/index.jsx
@@ -6,11 +6,10 @@ import LoadingSpinner from '../../components/LoadingSpinner';
 import { SEO } from '../../components/SEO';
 
 const EditPost = () => {
-  const { id } = useParams();
-  const { post, isLoading, error: fetchError } = usePostData(id);
-  const { error: updateError, isUpdating, updatePost } = useUpdatePost(id);
+  const { slug } = useParams(); // Changed from 'id' to 'slug'
+  const { post, isLoading, error: fetchError } = usePostData(slug);
+  const { error: updateError, isUpdating, updatePost } = useUpdatePost(slug);
 
-  // Combine errors from both hooks
   const error = fetchError || updateError;
 
   if (isLoading) {
@@ -19,8 +18,8 @@ const EditPost = () => {
         <SEO
           title="Edit Post"
           description="Update your content on StackNova."
-          canonicalPath={`/edit-post/${id}`}
-          noIndex={true} // Set noIndex to true based on robots.txt
+          canonicalPath={`/edit-post/${slug}`}
+          noIndex={true}
         />
         <LoadingSpinner text="Loading post..." />
       </>
@@ -32,8 +31,8 @@ const EditPost = () => {
       <SEO
         title={post ? `Edit: ${post.title}` : "Edit Post"}
         description="Update your content on StackNova."
-        canonicalPath={`/edit-post/${id}`}
-        noIndex={true} // Set noIndex to true based on robots.txt
+        canonicalPath={`/edit-post/${slug}`}
+        noIndex={true}
       />
       
       <section className="max-w-4xl mx-auto pb-8">

--- a/client/src/pages/NewPost/components/NewPostForm.jsx
+++ b/client/src/pages/NewPost/components/NewPostForm.jsx
@@ -9,7 +9,6 @@ export const NewPostForm = ({ onSubmit, isSubmitting, error, limits }) => {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
 
-  // Use limits from props if available, or fallback to defaults
   const MIN_CONTENT_CHARS = limits?.CONTENT_MIN || 5;
   const MAX_CONTENT_CHARS = limits?.CONTENT_MAX || 25000;
   const MAX_TITLE_CHARS = limits?.TITLE_MAX || 100;
@@ -47,7 +46,7 @@ export const NewPostForm = ({ onSubmit, isSubmitting, error, limits }) => {
             Content
           </label>
           <a
-            href="https://stacknova.ca/post/e8adb6bf-6d5e-4bb2-95cd-a74449e5041b"
+            href="https://stacknova.ca/post/formatting-guide"
             target="_blank"
             rel="noopener noreferrer"
             className="text-sm text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-500 flex items-center gap-1 group"

--- a/client/src/pages/NewPost/hooks/useCreatePost.js
+++ b/client/src/pages/NewPost/hooks/useCreatePost.js
@@ -19,13 +19,12 @@ export const useCreatePost = () => {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(postData),
-        credentials: 'include' // Include credentials for cross-domain sessions
+        credentials: 'include'
       });
 
       const responseData = await response.json();
 
       if (!response.ok) {
-        // If the server returned validation errors, format them nicely
         if (responseData.errors && Array.isArray(responseData.errors)) {
           const errorMessages = responseData.errors.map(err => err.msg).join('. ');
           throw new Error(errorMessages || 'Failed to create post');
@@ -35,33 +34,134 @@ export const useCreatePost = () => {
 
       return responseData;
     },
-    onSuccess: async (newPost) => {
-      // First invalidate the queries
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: ['userPosts', user?.id] }),
-        queryClient.invalidateQueries({ queryKey: ['posts'] }),
-        queryClient.invalidateQueries({ queryKey: ['user'] })
-      ]);
-
-      // Then update the cache optimistically
-      const currentPosts = queryClient.getQueryData(['userPosts', user?.id]) || [];
-      if (Array.isArray(currentPosts)) {
-        // Add the new post to the existing posts
-        queryClient.setQueryData(['userPosts', user?.id], [newPost, ...currentPosts]);
+    onMutate: async (newPostData) => {
+      // Cancel any outgoing refetches (so they don't overwrite our optimistic update)
+      await queryClient.cancelQueries({ queryKey: ['posts'] });
+      await queryClient.cancelQueries({ queryKey: ['userPosts', user?.id] });
+      if (user?.username) {
+        await queryClient.cancelQueries({ queryKey: ['user', user.username] });
       }
 
-      // Navigate to dashboard
-      navigate('/dashboard');
+      // Snapshot the previous value
+      const previousPosts = queryClient.getQueryData(['posts']);
+      const previousUserPosts = queryClient.getQueryData(['userPosts', user?.id]);
+      const previousUserProfile = user?.username ? queryClient.getQueryData(['user', user.username]) : null;
+
+      // Create optimistic post object
+      const optimisticPost = {
+        id: `temp-${Date.now()}`, // Temporary ID
+        title: newPostData.title,
+        content: newPostData.content,
+        excerpt: newPostData.content.substring(0, 150) + '...',
+        slug: `temp-slug-${Date.now()}`, // Temporary slug
+        user_id: user?.id,
+        username: user?.username,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        user: {
+          username: user?.username
+        },
+        comments: []
+      };
+
+      // Optimistically update posts list
+      if (Array.isArray(previousPosts)) {
+        queryClient.setQueryData(['posts'], [optimisticPost, ...previousPosts]);
+      }
+
+      // Optimistically update user posts
+      if (Array.isArray(previousUserPosts)) {
+        queryClient.setQueryData(['userPosts', user?.id], [optimisticPost, ...previousUserPosts]);
+      }
+
+      // Optimistically update user profile
+      if (user?.username && previousUserProfile) {
+        queryClient.setQueryData(['user', user.username], {
+          ...previousUserProfile,
+          posts: [optimisticPost, ...(previousUserProfile.posts || [])]
+        });
+      }
+
+      // Return a context object with the snapshotted value
+      return {
+        previousPosts,
+        previousUserPosts,
+        previousUserProfile,
+        optimisticPost
+      };
     },
-    onError: (error) => {
-      setError(error.message);
+    onError: (err, newPostData, context) => {
+      // If the mutation fails, use the context returned from onMutate to roll back
+      if (context?.previousPosts) {
+        queryClient.setQueryData(['posts'], context.previousPosts);
+      }
+      if (context?.previousUserPosts) {
+        queryClient.setQueryData(['userPosts', user?.id], context.previousUserPosts);
+      }
+      if (context?.previousUserProfile && user?.username) {
+        queryClient.setQueryData(['user', user.username], context.previousUserProfile);
+      }
+
+      setError(err.message);
+    },
+    onSuccess: async (newPost, variables, context) => {
+      // Replace the optimistic post with the real one
+      const realPost = newPost;
+
+      // Update posts list with real data
+      queryClient.setQueryData(['posts'], (oldPosts) => {
+        if (!Array.isArray(oldPosts)) return oldPosts;
+        return oldPosts.map(post =>
+          post.id === context?.optimisticPost?.id ? realPost : post
+        );
+      });
+
+      // Update user posts with real data
+      queryClient.setQueryData(['userPosts', user?.id], (oldPosts) => {
+        if (!Array.isArray(oldPosts)) return oldPosts;
+        return oldPosts.map(post =>
+          post.id === context?.optimisticPost?.id ? realPost : post
+        );
+      });
+
+      // Update user profile with real data
+      if (user?.username) {
+        queryClient.setQueryData(['user', user.username], (oldData) => {
+          if (!oldData) return oldData;
+          return {
+            ...oldData,
+            posts: oldData.posts?.map(post =>
+              post.id === context?.optimisticPost?.id ? realPost : post
+            ) || []
+          };
+        });
+      }
+
+      // Cache the new post individually for immediate access
+      if (realPost.slug) {
+        queryClient.setQueryData(['post', realPost.slug], realPost);
+      }
+
+      // Navigate to the new post using real slug
+      if (realPost.slug) {
+        navigate(`/post/${realPost.slug}`);
+      } else {
+        navigate('/dashboard');
+      }
+    },
+    onSettled: () => {
+      // Always refetch after error or success to ensure we have the latest data
+      queryClient.invalidateQueries({ queryKey: ['posts'] });
+      queryClient.invalidateQueries({ queryKey: ['userPosts', user?.id] });
+      if (user?.username) {
+        queryClient.invalidateQueries({ queryKey: ['user', user.username] });
+      }
     },
   });
 
   const handleCreatePost = (postData) => {
     setError('');
 
-    // Client-side validation with specific error messages
     if (!postData.title.trim()) {
       setError('Title is required');
       return;
@@ -87,7 +187,6 @@ export const useCreatePost = () => {
       return;
     }
 
-    // Validate code blocks
     if (!validateCodeBlocks(postData.content)) {
       setError(`Code blocks must be less than ${POST_LIMITS.CODE_BLOCK_MAX} characters`);
       return;

--- a/client/src/pages/PostDetails/components/CommentForm.jsx
+++ b/client/src/pages/PostDetails/components/CommentForm.jsx
@@ -10,7 +10,7 @@ export const CommentForm = ({
 }) => (
   <div className="mb-8">
     <h4 id="comment-form" className="text-xl font-semibold text-gray-900 dark:text-white mb-4">
-      {isEditing ? 'Edit your comment' : 'Share your thoughts!'}
+      {isEditing ? 'Edit your comment' : 'Add a comment'}
     </h4>
     <form onSubmit={onSubmit}>
       <MarkdownEditor

--- a/client/src/pages/PostDetails/hooks/useComments.js
+++ b/client/src/pages/PostDetails/hooks/useComments.js
@@ -1,26 +1,41 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { useAuth } from '../../../context/AuthContext';
 
-export const useComments = (postId) => {
+export const useComments = (postSlug) => {
   const [editingCommentId, setEditingCommentId] = useState(null);
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [commentToDelete, setCommentToDelete] = useState(null);
   const queryClient = useQueryClient();
+  const { user } = useAuth();
 
   const addCommentMutation = useMutation({
     mutationFn: async (newComment) => {
       const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/comments`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(newComment)
+        body: JSON.stringify(newComment),
+        credentials: 'include'
       });
       if (!response.ok) throw new Error('Failed to add comment');
       return response.json();
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['posts'] });
-      queryClient.invalidateQueries({ queryKey: ['post', postId] });
-      queryClient.invalidateQueries({ queryKey: ['user'] });
+    onSuccess: async () => {
+      // Force immediate cache removal for current user to show loading
+      if (user?.username) {
+        queryClient.removeQueries({ queryKey: ['user', user.username] });
+      }
+
+      // Then invalidate other caches
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['posts'] }),
+        queryClient.invalidateQueries({ queryKey: ['post', postSlug] }),
+        queryClient.invalidateQueries({
+          queryKey: ['user'],
+          exact: false,
+          refetchType: 'active'
+        })
+      ]);
     }
   });
 
@@ -29,15 +44,28 @@ export const useComments = (postId) => {
       const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/comments/${commentId}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ comment_text: updatedText })
+        body: JSON.stringify({ comment_text: updatedText }),
+        credentials: 'include'
       });
       if (!response.ok) throw new Error('Failed to edit comment');
       return response.json();
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['posts'] });
-      queryClient.invalidateQueries({ queryKey: ['post', postId] });
-      queryClient.invalidateQueries({ queryKey: ['user'] });
+    onSuccess: async () => {
+      // Force immediate cache removal for current user
+      if (user?.username) {
+        queryClient.removeQueries({ queryKey: ['user', user.username] });
+      }
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['posts'] }),
+        queryClient.invalidateQueries({ queryKey: ['post', postSlug] }),
+        queryClient.invalidateQueries({
+          queryKey: ['user'],
+          exact: false,
+          refetchType: 'active'
+        })
+      ]);
+
       setEditingCommentId(null);
     }
   });
@@ -45,14 +73,27 @@ export const useComments = (postId) => {
   const deleteCommentMutation = useMutation({
     mutationFn: async (commentId) => {
       const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/comments/${commentId}`, {
-        method: 'DELETE'
+        method: 'DELETE',
+        credentials: 'include'
       });
       if (!response.ok) throw new Error('Failed to delete comment');
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['posts'] });
-      queryClient.invalidateQueries({ queryKey: ['post', postId] });
-      queryClient.invalidateQueries({ queryKey: ['user'] });
+    onSuccess: async () => {
+      // Force immediate cache removal for current user
+      if (user?.username) {
+        queryClient.removeQueries({ queryKey: ['user', user.username] });
+      }
+
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ['posts'] }),
+        queryClient.invalidateQueries({ queryKey: ['post', postSlug] }),
+        queryClient.invalidateQueries({
+          queryKey: ['user'],
+          exact: false,
+          refetchType: 'active'
+        })
+      ]);
+
       setDeleteModalOpen(false);
       setCommentToDelete(null);
     }

--- a/client/src/pages/PostDetails/hooks/usePost.js
+++ b/client/src/pages/PostDetails/hooks/usePost.js
@@ -1,15 +1,55 @@
 import { useQuery } from '@tanstack/react-query';
 
-export const usePost = (id) => {
+export const usePost = (identifier) => {
   return useQuery({
-    queryKey: ['post', id],
+    queryKey: ['post', identifier],
     queryFn: async () => {
-      const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/posts/${id}`);
+      const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/posts/${identifier}`, {
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json'
+        }
+      });
       if (!response.ok) throw new Error('Failed to fetch post');
       return response.json();
     },
-    // Caching configuration
-    staleTime: 1000 * 60 * 5, // Consider data fresh for 5 minute
-    cacheTime: 1000 * 60 * 30 // Keep data in cache for 30 minutes
+    staleTime: 1000 * 60 * 5,
+    cacheTime: 1000 * 60 * 30
   });
 };
+
+// ----------------------------------------------------------------------------
+
+// import { useQuery } from '@tanstack/react-query';
+
+// export const usePost = (id) => {
+//   return useQuery({
+//     queryKey: ['post', id],
+//     queryFn: async () => {
+//       const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/posts/${id}`);
+//       if (!response.ok) throw new Error('Failed to fetch post');
+//       return response.json();
+//     },
+//     // Caching configuration
+//     staleTime: 1000 * 60 * 5, // Consider data fresh for 5 minute
+//     cacheTime: 1000 * 60 * 30 // Keep data in cache for 30 minutes
+//   });
+// };
+
+// ----------------------------------------------------------------------------
+
+// import { useQuery } from '@tanstack/react-query';
+
+// export const usePost = (slug) => {
+//   return useQuery({
+//     queryKey: ['post', slug],
+//     queryFn: async () => {
+//       const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/posts/${slug}`);
+//       if (!response.ok) throw new Error('Failed to fetch post');
+//       return response.json();
+//     },
+//     staleTime: 1000 * 60 * 5,
+//     cacheTime: 1000 * 60 * 30
+//   });
+// };
+

--- a/client/src/pages/PostDetails/index.jsx
+++ b/client/src/pages/PostDetails/index.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useParams, Link, useLocation } from 'react-router-dom';
+import { useParams, Link, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import NotFound from '../NotFound';
@@ -10,14 +10,17 @@ import { PostContent } from './components/PostContent';
 import { CommentForm } from './components/CommentForm';
 import { CommentsList } from './components/CommentsList';
 import { SEO } from '../../components/SEO';
+import { useQueryClient } from '@tanstack/react-query';
 
 const PostDetails = () => {
-  const { id } = useParams();
+  const { identifier } = useParams(); // Changed from slug to identifier
+  const navigate = useNavigate(); // Added for redirects
+  const queryClient = useQueryClient()
   const [commentText, setCommentText] = useState('');
   const { isAuthenticated, user } = useAuth();
   const location = useLocation();
 
-  const { data: post, isLoading, error, isError } = usePost(id);
+  const { data: post, isLoading, error, isError } = usePost(identifier); // Use identifier instead of slug
   const {
     editingCommentId,
     setEditingCommentId,
@@ -29,7 +32,21 @@ const PostDetails = () => {
     deleteCommentMutation,
     handleEditClick,
     handleDeleteClick
-  } = useComments(id);
+  } = useComments(post?.slug || identifier); // Fallback to identifier if no slug
+
+  // Helper function to check if identifier is UUID
+  const isUUID = (str) => {
+    const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+    return uuidRegex.test(str);
+  };
+
+  // Handle UUID -> slug redirect
+  useEffect(() => {
+    if (post && post.slug && identifier !== post.slug && isUUID(identifier)) {
+      // Replace the UUID URL with the slug URL
+      navigate(`/post/${post.slug}`, { replace: true });
+    }
+  }, [post, identifier, navigate]);
 
   // Effect to handle body scroll lock when modal is open
   useEffect(() => {
@@ -47,6 +64,14 @@ const PostDetails = () => {
     }
   }, [deleteModalOpen]);
 
+  useEffect(() => {
+    const isFromEdit = location.state?.fromEdit;
+    if (isFromEdit) {
+      // Force refetch the post data using the current identifier
+      queryClient.invalidateQueries({ queryKey: ['post', identifier] });
+    }
+  }, [identifier, location.state, queryClient]); // Use identifier instead of slug
+
   const handleSubmit = (e) => {
     e.preventDefault();
 
@@ -60,7 +85,7 @@ const PostDetails = () => {
     } else {
       addCommentMutation.mutate({
         comment_text: commentText,
-        post_id: id
+        post_id: post.id // Use post.id for the API call, not identifier
       }, {
         onSuccess: () => setCommentText('')
       });
@@ -80,7 +105,7 @@ const PostDetails = () => {
   // Generate enhanced JSON-LD for the blog post
   const generateJsonLd = (post) => {
     if (!post) return null;
-    
+
     return {
       "@context": "https://schema.org",
       "@type": "BlogPosting",
@@ -104,7 +129,7 @@ const PostDetails = () => {
       },
       "mainEntityOfPage": {
         "@type": "WebPage",
-        "@id": `https://stacknova.ca/post/${post.id}`
+        "@id": `https://stacknova.ca/post/${post.slug || identifier}` // Use slug if available, fallback to identifier
       },
       "commentCount": post.comments?.length || 0,
       "comment": post.comments?.map(comment => ({
@@ -123,12 +148,12 @@ const PostDetails = () => {
     return <LoadingSpinner text="Loading post..." />;
   }
 
-  // Use the flexible NotFound component for posts that don't exist
   if (isError || !post) {
+    const displayName = isUUID(identifier) ? 'this post' : `"${identifier}"`;
     return (
       <NotFound
         title="Post not found"
-        message={`The post with ID "${id}" does not exist or could not be found.`}
+        message={`The post ${displayName} does not exist or could not be found.`}
         linkText="Browse all posts"
         linkTo="/"
       />
@@ -140,7 +165,7 @@ const PostDetails = () => {
       <SEO
         title={post.title}
         description={post.excerpt || `A question by ${post.user.username} on StackNova`}
-        canonicalPath={`/post/${post.id}`}
+        canonicalPath={`/post/${post.slug || identifier}`} // Use slug if available
         type="article"
         image="https://stacknova.ca/screenshots/2-StackNova-Question.jpg"
         jsonLd={generateJsonLd(post)}
@@ -168,15 +193,14 @@ const PostDetails = () => {
         <div className="mb-8 p-4 bg-white dark:bg-gray-800 rounded-lg text-center border 
         border-gray-200 dark:border-gray-700">
           <p className="text-gray-900 dark:text-white">
-            Please{' '}
+            You must be logged in to comment.{' '}
             <Link
               to="/login"
               state={{ from: location.pathname }}
               className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-500"
             >
-              log in
-            </Link>{' '}
-            to comment on this post.
+              Log in here.
+            </Link>
           </p>
         </div>
       )}
@@ -193,3 +217,210 @@ const PostDetails = () => {
 };
 
 export default PostDetails;
+
+// ----------------------------------------------------------------------------
+
+// import { useState, useEffect } from 'react';
+// import { useParams, Link, useLocation } from 'react-router-dom';
+// import { useAuth } from '../../context/AuthContext';
+// import LoadingSpinner from '../../components/LoadingSpinner';
+// import NotFound from '../NotFound';
+// import { usePost } from './hooks/usePost';
+// import { useComments } from './hooks/useComments';
+// import { DeleteModal } from './components/DeleteModal';
+// import { PostContent } from './components/PostContent';
+// import { CommentForm } from './components/CommentForm';
+// import { CommentsList } from './components/CommentsList';
+// import { SEO } from '../../components/SEO';
+
+// import { useQueryClient } from '@tanstack/react-query';
+
+// const PostDetails = () => {
+//   const { slug } = useParams();
+//   const queryClient = useQueryClient()
+//   const [commentText, setCommentText] = useState('');
+//   const { isAuthenticated, user } = useAuth();
+//   const location = useLocation();
+
+//   const { data: post, isLoading, error, isError } = usePost(slug);
+//   const {
+//     editingCommentId,
+//     setEditingCommentId,
+//     deleteModalOpen,
+//     setDeleteModalOpen,
+//     commentToDelete,
+//     addCommentMutation,
+//     editCommentMutation,
+//     deleteCommentMutation,
+//     handleEditClick,
+//     handleDeleteClick
+//   } = useComments(post?.slug); // Pass slug instead of post.id
+
+//   // Effect to handle body scroll lock when modal is open
+//   useEffect(() => {
+//     if (deleteModalOpen) {
+//       const scrollY = window.scrollY;
+//       document.body.style.position = 'fixed';
+//       document.body.style.top = `-${scrollY}px`;
+//       document.body.style.width = '100%';
+//     } else {
+//       const scrollY = document.body.style.top;
+//       document.body.style.position = '';
+//       document.body.style.top = '';
+//       document.body.style.width = '';
+//       window.scrollTo(0, parseInt(scrollY || '0', 10) * -1);
+//     }
+//   }, [deleteModalOpen]);
+
+//   useEffect(() => {
+//     const isFromEdit = location.state?.fromEdit;
+//     if (isFromEdit) {
+//       // Force refetch the post data
+//       queryClient.invalidateQueries({ queryKey: ['post', slug] });
+//     }
+//   }, [slug, location.state, queryClient]);
+
+//   const handleSubmit = (e) => {
+//     e.preventDefault();
+
+//     if (editingCommentId) {
+//       editCommentMutation.mutate({
+//         commentId: editingCommentId,
+//         updatedText: commentText
+//       }, {
+//         onSuccess: () => setCommentText('')
+//       });
+//     } else {
+//       addCommentMutation.mutate({
+//         comment_text: commentText,
+//         post_id: post.id // Use post.id for the API call, not slug
+//       }, {
+//         onSuccess: () => setCommentText('')
+//       });
+//     }
+//   };
+
+//   const handleCancelEdit = () => {
+//     setEditingCommentId(null);
+//     setCommentText('');
+//   };
+
+//   const handleCommentEdit = (comment) => {
+//     handleEditClick(comment);
+//     setCommentText(comment.comment_text);
+//   };
+
+//   // Generate enhanced JSON-LD for the blog post
+//   const generateJsonLd = (post) => {
+//     if (!post) return null;
+
+//     return {
+//       "@context": "https://schema.org",
+//       "@type": "BlogPosting",
+//       "headline": post.title,
+//       "description": post.excerpt,
+//       "image": "https://stacknova.ca/screenshots/2-StackNova-Question.jpg",
+//       "datePublished": post.createdAt,
+//       "dateModified": post.updatedAt || post.createdAt,
+//       "author": {
+//         "@type": "Person",
+//         "name": post.user.username,
+//         "url": `https://stacknova.ca/user/${post.user.username}`,
+//       },
+//       "publisher": {
+//         "@type": "Organization",
+//         "name": "StackNova",
+//         "logo": {
+//           "@type": "ImageObject",
+//           "url": "https://stacknova.ca/favicon.svg"
+//         }
+//       },
+//       "mainEntityOfPage": {
+//         "@type": "WebPage",
+//         "@id": `https://stacknova.ca/post/${post.slug}` // Use slug for canonical URL
+//       },
+//       "commentCount": post.comments?.length || 0,
+//       "comment": post.comments?.map(comment => ({
+//         "@type": "Comment",
+//         "text": comment.comment_text,
+//         "dateCreated": comment.createdAt,
+//         "author": {
+//           "@type": "Person",
+//           "name": comment.user.username
+//         }
+//       })) || []
+//     };
+//   };
+
+//   if (isLoading) {
+//     return <LoadingSpinner text="Loading post..." />;
+//   }
+
+//   if (isError || !post) {
+//     return (
+//       <NotFound
+//         title="Post not found"
+//         message={`The post "${slug}" does not exist or could not be found.`}
+//         linkText="Browse all posts"
+//         linkTo="/"
+//       />
+//     );
+//   }
+
+//   return (
+//     <div className="max-w-4xl mx-auto pb-8">
+//       <SEO
+//         title={post.title}
+//         description={post.excerpt || `A question by ${post.user.username} on StackNova`}
+//         canonicalPath={`/post/${post.slug}`}
+//         type="article"
+//         image="https://stacknova.ca/screenshots/2-StackNova-Question.jpg"
+//         jsonLd={generateJsonLd(post)}
+//       />
+
+//       <DeleteModal
+//         isOpen={deleteModalOpen}
+//         onClose={() => setDeleteModalOpen(false)}
+//         onConfirm={() => deleteCommentMutation.mutate(commentToDelete?.id)}
+//         isDeleting={deleteCommentMutation.isPending}
+//       />
+
+//       <PostContent post={post} />
+
+//       {isAuthenticated ? (
+//         <CommentForm
+//           commentText={commentText}
+//           setCommentText={setCommentText}
+//           isEditing={!!editingCommentId}
+//           onSubmit={handleSubmit}
+//           onCancelEdit={handleCancelEdit}
+//           isSubmitting={addCommentMutation.isPending || editCommentMutation.isPending}
+//         />
+//       ) : (
+//         <div className="mb-8 p-4 bg-white dark:bg-gray-800 rounded-lg text-center border 
+//         border-gray-200 dark:border-gray-700">
+//           <p className="text-gray-900 dark:text-white">
+//             You must be logged in to comment.{' '}
+//             <Link
+//               to="/login"
+//               state={{ from: location.pathname }}
+//               className="text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-500"
+//             >
+//               Log in here.
+//             </Link>
+//           </p>
+//         </div>
+//       )}
+
+//       <CommentsList
+//         comments={post.comments}
+//         currentUserId={user?.id}
+//         onEditComment={handleCommentEdit}
+//         onDeleteComment={handleDeleteClick}
+//         isEditingComment={editingCommentId}
+//       />
+//     </div>
+//   );
+// };
+
+// export default PostDetails;

--- a/client/src/pages/Posts/components/PostItem.jsx
+++ b/client/src/pages/Posts/components/PostItem.jsx
@@ -9,10 +9,10 @@ export const PostItem = ({ post, prefetchPost }) => {
   return (
     <article className="h-full">
       <Link
-        to={`/post/${post.id}`}
-        onMouseEnter={() => prefetchPost(post.id)}
+        to={`/post/${post.slug}`}
+        onMouseEnter={() => prefetchPost(post.slug)}
         className="block group h-full"
-        aria-labelledby={`post-title-${post.id}`}
+        aria-labelledby={`post-title-${post.slug}`}
       >
         <div className="bg-white dark:bg-gray-800 rounded-lg p-4 
                       border border-gray-200 dark:border-gray-700
@@ -21,7 +21,7 @@ export const PostItem = ({ post, prefetchPost }) => {
           <div className="flex justify-between items-start gap-4">
             <div className="flex-1">
               <h2
-                id={`post-title-${post.id}`}
+                id={`post-title-${post.slug}`}
                 className="text-xl font-semibold text-blue-600 dark:text-blue-400 mb-2 
                         group-hover:text-blue-700 dark:group-hover:text-blue-500"
               >

--- a/client/src/pages/Posts/hooks/usePrefetchPost.js
+++ b/client/src/pages/Posts/hooks/usePrefetchPost.js
@@ -1,34 +1,35 @@
+// Updated usePrefetchPost.js
 import { useCallback } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
 export const usePrefetchPost = () => {
   const queryClient = useQueryClient();
 
-  return useCallback((postId) => {
+  return useCallback((postSlug) => { // Renamed from postId to postSlug for clarity
     // Skip prefetching if the user has data-saving mode enabled
     if (navigator.connection && navigator.connection.saveData) return;
-    // Skip if no postId (shouldn't happen, but just in case)
-    if (!postId) return;
-    // Skip if the postId is already in the cache
-    if (queryClient.getQueryData(['post', postId.toString()])) return;
+    // Skip if no postSlug (shouldn't happen, but just in case)
+    if (!postSlug) return;
+    // Skip if the postSlug is already in the cache
+    if (queryClient.getQueryData(['post', postSlug.toString()])) return;
 
     let timer;
     clearTimeout(timer);
     timer = setTimeout(() => {
       queryClient.prefetchQuery({
-        queryKey: ['post', postId.toString()],
+        queryKey: ['post', postSlug.toString()],
         queryFn: async () => {
           try {
-            const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/posts/${postId}`);
+            const response = await fetch(`${import.meta.env.VITE_API_BASE_URL}/posts/${postSlug}`);
             if (!response.ok) {
               // We can be less aggressive with error handling for prefetch
-              console.warn(`Failed to prefetch post ${postId}: ${response.status}`);
+              console.warn(`Failed to prefetch post ${postSlug}: ${response.status}`);
               return null;
             }
             return response.json();
           } catch (error) {
             // Log but don't throw for prefetch errors
-            console.warn(`Error prefetching post ${postId}:`, error);
+            console.warn(`Error prefetching post ${postSlug}:`, error);
             return null;
           }
         },

--- a/client/src/pages/Posts/index.jsx
+++ b/client/src/pages/Posts/index.jsx
@@ -36,7 +36,7 @@ const Posts = () => {
           "@type": "BlogPosting",
           "headline": post.title,
           "description": post.excerpt,
-          "url": `https://stacknova.ca/post/${post.id}`,
+          "url": `https://stacknova.ca/post/${post.slug}`, // Fixed: use slug instead of id
           "datePublished": post.createdAt,
           "author": {
             "@type": "Person",
@@ -53,7 +53,7 @@ const Posts = () => {
       <SEO
         title="Latest Posts"
         description="Discover and engage with the latest programming insights, technical solutions, and developer discussions on StackNova. Share your knowledge and connect with a community of passionate developers."
-        canonicalPath="" // Root path is the canonical URL
+        canonicalPath=""
         jsonLd={jsonLd}
       />
 

--- a/client/src/pages/UserProfile/components/UserComments.jsx
+++ b/client/src/pages/UserProfile/components/UserComments.jsx
@@ -98,11 +98,11 @@ export const UserComments = ({ comments, prefetchPost }) => {
           )}
           <p className="text-sm text-gray-600 dark:text-gray-400">
             on <Link
-              to={`/post/${comment.post.id}`}
+              to={`/post/${comment.post.slug}`}
               className="text-blue-600 dark:text-blue-400 font-medium underline-offset-2
               hover:text-blue-700 dark:hover:text-blue-500"
-              onMouseEnter={() => prefetchPost(comment.post.id)}
-              onFocus={() => prefetchPost(comment.post.id)}
+              onMouseEnter={() => prefetchPost(comment.post.slug)}
+              onFocus={() => prefetchPost(comment.post.slug)}
             >
               {comment.post.title}
             </Link>

--- a/client/src/pages/UserProfile/index.jsx
+++ b/client/src/pages/UserProfile/index.jsx
@@ -14,13 +14,10 @@ const UserProfile = () => {
   const { username } = useParams();
   const queryClient = useQueryClient();
 
-  // Check if we have prefetched data
   const prefetchedData = queryClient.getQueryData(['user', username]);
 
-  // Use suspense mode only for initial loading, but handle errors normally
   const { data: user, error, isError, isLoading, status } = useUserProfile(username, {
-    suspense: false, // Don't use suspense for error handling
-    // If we have prefetched data, we don't need to show loading states
+    suspense: false,
     initialData: prefetchedData
   });
 
@@ -47,18 +44,16 @@ const UserProfile = () => {
         "publishedPosts": user.posts?.map(post => ({
           "@type": "BlogPosting",
           "headline": post.title,
-          "url": `https://stacknova.ca/post/${post.id}`
+          "url": `https://stacknova.ca/post/${post.slug}`
         })) || []
       }
     };
   };
 
-  // First show loading state if not prefetched
   if (isLoading) {
     return <LoadingSpinner text="Loading profile..." />;
   }
 
-  // After loading completes, show NotFound if there was an error or no user
   if (isError || (!isLoading && !user)) {
     return (
       <NotFound

--- a/server/controllers/commentController.js
+++ b/server/controllers/commentController.js
@@ -1,4 +1,4 @@
-const { Comment, User } = require('../models');
+const { Comment, User, Post } = require('../models'); // Add Post model
 const redisService = require('../config/redis');
 
 // Helper function to handle common Redis cache operations
@@ -10,7 +10,16 @@ async function clearCaches(postId, userId, username) {
   ];
 
   if (postId) {
-    cacheOps.push(redisService.clearPostCache(postId, true)); // Include comments
+    // Clear cache for both post ID and slug
+    const post = await Post.findByPk(postId, { attributes: ['id', 'slug'] });
+    if (post) {
+      // Clear cache for both UUID and slug versions
+      cacheOps.push(redisService.clearPostCache(post.id, true)); // UUID version
+      cacheOps.push(redisService.clearPostCache(post.slug, true)); // Slug version
+    } else {
+      // Fallback: just clear by ID if post not found
+      cacheOps.push(redisService.clearPostCache(postId, true));
+    }
   }
 
   if (userId) {
@@ -142,3 +151,150 @@ const commentController = {
 };
 
 module.exports = commentController;
+
+// ----------------------------------------------------------------------------
+
+// const { Comment, User } = require('../models');
+// const redisService = require('../config/redis');
+
+// // Helper function to handle common Redis cache operations
+// async function clearCaches(postId, userId, username) {
+//   const cacheOps = [
+//     redisService.clearHomePageCache(),
+//     redisService.clearUserProfileCache(username),
+//     redisService.invalidateSitemapCache()
+//   ];
+
+//   if (postId) {
+//     cacheOps.push(redisService.clearPostCache(postId, true)); // Include comments
+//   }
+
+//   if (userId) {
+//     cacheOps.push(redisService.clearUserPostsCache(userId));
+//   }
+
+//   return Promise.all(cacheOps);
+// }
+
+// const commentController = {
+//   // Create a new comment
+//   async createComment(req, res) {
+//     try {
+//       const userId = req.session.user_id;
+//       const postId = req.body.post_id;
+
+//       if (!userId) {
+//         return res.status(401).json({ message: 'You must be logged in to create a comment' });
+//       }
+
+//       if (!postId) {
+//         return res.status(400).json({ message: 'Post ID is required' });
+//       }
+
+//       // Get the user to access username
+//       const user = await User.findByPk(userId, {
+//         attributes: ['username']
+//       });
+
+//       if (!user) {
+//         return res.status(404).json({ message: 'User not found' });
+//       }
+
+//       const newComment = await Comment.create({
+//         comment_text: req.body.comment_text,
+//         user_id: userId,
+//         post_id: postId
+//       });
+
+//       // Clear relevant caches
+//       await clearCaches(postId, userId, user.username);
+
+//       res.status(201).json(newComment.get({ plain: true }));
+//     } catch (err) {
+//       console.error('Error creating comment:', err);
+//       res.status(400).json({ message: 'Failed to create comment', error: err.message });
+//     }
+//   },
+
+//   // Update a comment
+//   async updateComment(req, res) {
+//     try {
+//       const userId = req.session.user_id;
+//       const commentId = req.params.id;
+
+//       if (!userId) {
+//         return res.status(401).json({ message: 'You must be logged in to update a comment' });
+//       }
+
+//       const comment = await Comment.findOne({
+//         where: {
+//           id: commentId,
+//           user_id: userId
+//         },
+//         include: [{
+//           model: User,
+//           attributes: ['username']
+//         }]
+//       });
+
+//       if (!comment) {
+//         return res.status(404).json({ message: 'No comment found with this id or you are not authorized to edit it' });
+//       }
+
+//       await comment.update({ comment_text: req.body.comment_text });
+
+//       // Clear relevant caches
+//       await clearCaches(comment.post_id, userId, comment.user.username);
+
+//       res.status(200).json({
+//         message: 'Comment updated successfully',
+//         comment: comment.get({ plain: true })
+//       });
+//     } catch (err) {
+//       console.error('Error updating comment:', err);
+//       res.status(500).json({ message: 'Failed to update comment', error: err.message });
+//     }
+//   },
+
+//   // Delete a comment
+//   async deleteComment(req, res) {
+//     try {
+//       const userId = req.session.user_id;
+//       const commentId = req.params.id;
+
+//       if (!userId) {
+//         return res.status(401).json({ message: 'You must be logged in to delete a comment' });
+//       }
+
+//       const comment = await Comment.findOne({
+//         where: {
+//           id: commentId,
+//           user_id: userId
+//         },
+//         include: [{
+//           model: User,
+//           attributes: ['username']
+//         }]
+//       });
+
+//       if (!comment) {
+//         return res.status(404).json({ message: 'No comment found with this id or you are not authorized to delete it' });
+//       }
+
+//       const postId = comment.post_id;
+//       const username = comment.user.username;
+
+//       await comment.destroy();
+
+//       // Clear relevant caches
+//       await clearCaches(postId, userId, username);
+
+//       res.status(200).json({ message: 'Comment deleted successfully' });
+//     } catch (err) {
+//       console.error('Error deleting comment:', err);
+//       res.status(500).json({ message: 'Failed to delete comment', error: err.message });
+//     }
+//   }
+// };
+
+// module.exports = commentController;

--- a/server/models/Post.js
+++ b/server/models/Post.js
@@ -4,7 +4,6 @@ const { generateExcerpt } = require('../utils/excerptUtils');
 
 class Post extends Model { }
 
-// Initialize Post model with columns and configuration
 Post.init(
   {
     id: {
@@ -16,6 +15,15 @@ Post.init(
     title: {
       type: DataTypes.STRING,
       allowNull: false,
+    },
+    slug: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      unique: true,
+      validate: {
+        len: [1, 255],
+        is: /^[a-z0-9-]+$/,
+      },
     },
     content: {
       type: DataTypes.TEXT,
@@ -36,13 +44,12 @@ Post.init(
   {
     hooks: {
       beforeCreate: async (post) => {
-        // Generate excerpt for new posts
+        // Only handle excerpt generation
         if (post.content) {
           post.excerpt = generateExcerpt(post.content);
         }
       },
       beforeUpdate: async (post) => {
-        // Regenerate excerpt if content has changed
         if (post.changed('content')) {
           post.excerpt = generateExcerpt(post.content);
         }

--- a/server/routes/api/postRoutes.js
+++ b/server/routes/api/postRoutes.js
@@ -5,11 +5,29 @@ const cacheMiddleware = require('../../middleware/cache');
 const { postLimiter } = require('../../middleware/rateLimiter');
 const { validateNewPost, validatePostUpdate } = require('../../middleware/validate');
 
+// Get all posts
 router.get('/', cacheMiddleware, postController.getAllPosts);
-router.get('/user/posts', cacheMiddleware, postController.getUserPosts);
-router.get('/:id', cacheMiddleware, postController.getSinglePost);
+
+// Get posts for current user
+router.get('/user/posts', withAuth, cacheMiddleware, postController.getUserPosts);
+
+// Get a single post by slug or ID
+router.get('/:identifier', cacheMiddleware, postController.getSinglePost);
+
+// Create a new post
 router.post('/', withAuth, postLimiter, validateNewPost, postController.createPost);
-router.put('/:id', withAuth, validatePostUpdate, postController.updatePost);
-router.delete('/:id', withAuth, postController.deletePost);
+
+// Update a post by slug or ID
+router.put('/:identifier', withAuth, validatePostUpdate, postController.updatePost);
+
+// Delete a post by slug or ID
+router.delete('/:identifier', withAuth, postController.deletePost);
+
+// router.get('/', cacheMiddleware, postController.getAllPosts);
+// router.get('/user/posts', cacheMiddleware, postController.getUserPosts);
+// router.get('/:id', cacheMiddleware, postController.getSinglePost);
+// router.post('/', withAuth, postLimiter, validateNewPost, postController.createPost);
+// router.put('/:id', withAuth, validatePostUpdate, postController.updatePost);
+// router.delete('/:id', withAuth, postController.deletePost);
 
 module.exports = router;

--- a/server/utils/slugUtils.js
+++ b/server/utils/slugUtils.js
@@ -1,0 +1,43 @@
+const { Post } = require('../models');
+
+// Utility function to generate URL-safe slugs
+const generateSlug = (title) => {
+  return title
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\s_-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+};
+
+// Function to ensure slug uniqueness
+const generateUniqueSlug = async (title, excludeId = null) => {
+  let baseSlug = generateSlug(title);
+  let slug = baseSlug;
+  let counter = 1;
+
+  while (true) {
+    const whereClause = { slug };
+    if (excludeId) {
+      whereClause.id = { [require('sequelize').Op.ne]: excludeId };
+    }
+
+    const existingPost = await Post.findOne({ where: whereClause });
+    
+    if (!existingPost) {
+      return slug;
+    }
+    
+    slug = `${baseSlug}-${counter}`;
+    counter++;
+    
+    if (counter > 1000) {
+      throw new Error('Unable to generate unique slug after 1000 attempts');
+    }
+  }
+};
+
+module.exports = {
+  generateSlug,
+  generateUniqueSlug
+};


### PR DESCRIPTION
- Add slug field to Post model with automatic generation
- Update controllers to handle both slugs and UUIDs for backward compatibility  
- Migrate all frontend components to use slug-based URLs
- Fix Redis cache invalidation for slug/UUID dual keys
- Update prefetching and navigation to use slugs
- Add database migration for existing posts
- Maintain 301 redirects from old UUID URLs to new slug URLs

URLs now use clean, readable format: /post/how-to-create-a-python-virtual-environment
Improves SEO, user experience, and link shareability.