### PR TITLE
fix missing comments in post update response

### DIFF
--- a/server/controllers/postController.js
+++ b/server/controllers/postController.js
@@ -283,12 +283,17 @@ const postController = {
 
       await post.update(updateData);
 
+      // Fetch the updated post with all relations (including comments)
+      const updatedPostWithDetails = await Post.findByPk(post.id, {
+        ...postQueryOptions // This includes User and Comments
+      });
+
       // Clear relevant caches BEFORE sending response
       await clearCaches(post.id, userId, post.user.username);
 
       res.status(200).json({
         message: 'Post updated successfully!',
-        post: post.get({ plain: true })
+        post: updatedPostWithDetails.get({ plain: true }) // Includes comments
       });
     } catch (err) {
       console.error('Error updating post:', err);


### PR DESCRIPTION
When updating a post, the response now includes the complete post data with comments. Previously, the update endpoint only returned the post without comments, causing them to disappear from the UI until refresh.

- Fetch updated post with full relations (User + Comments) after update
- Use postQueryOptions to ensure consistent data structure
- Resolves issue where comments vanished after editing post title